### PR TITLE
起動時にswapコマンドも有効化

### DIFF
--- a/keymaps/swaptab-atom.cson
+++ b/keymaps/swaptab-atom.cson
@@ -8,6 +8,5 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-workspace':
-  'ctrl-alt-o': 'swaptab-atom:toggle'
   'shift-cmd-J': 'swaptab-atom:move-tab-right'
   'shift-cmd-K': 'swaptab-atom:move-tab-left'

--- a/lib/swaptab-atom.coffee
+++ b/lib/swaptab-atom.coffee
@@ -13,7 +13,7 @@ module.exports = SwaptabAtom =
     @subscriptions = new CompositeDisposable
 
     # Register command that toggles this view
-    @subscriptions.add atom.commands.add 'atom-workspace', 'swaptab-atom:toggle': => @toggle()
+    # @subscriptions.add atom.commands.add 'atom-workspace', 'swaptab-atom:toggle': => @toggle()
     @subscriptions.add atom.commands.add 'atom-workspace', 'swaptab-atom:move-tab-right': => @moveRight()
     @subscriptions.add atom.commands.add 'atom-workspace', 'swaptab-atom:move-tab-left': => @moveLeft()
 
@@ -33,8 +33,8 @@ module.exports = SwaptabAtom =
   serialize: ->
     # swaptabAtomViewState: @swaptabAtomView.serialize()
 
-  toggle: ->
-    console.log 'SwaptabAtom was toggled!'
+  # toggle: ->
+  #   console.log 'SwaptabAtom was toggled!'
 
     # if @modalPanel.isVisible()
     #   @modalPanel.hide()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "description": "Move your active tab with ease",
   "activationCommands": {
-    "atom-workspace": "swaptab-atom:toggle",
     "atom-workspace": "swaptab-atom:move-tab-right",
     "atom-workspace": "swaptab-atom:move-tab-left"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "description": "Move your active tab with ease",
   "activationCommands": {
-    "atom-workspace": "swaptab-atom:toggle"
+    "atom-workspace": "swaptab-atom:toggle",
+    "atom-workspace": "swaptab-atom:move-tab-right",
+    "atom-workspace": "swaptab-atom:move-tab-left"
   },
   "repository": "https://github.com/atom/atom",
   "license": "MIT",


### PR DESCRIPTION
## Why
- `swaptab-atom:move-tab-right` と `swaptab-atom:move-tab-left` が最初きかない
## How
- `package.json` の `activationCommands` に追加
